### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -114,7 +114,7 @@ if '__main__' == __name__:
     import argparse
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--repo', default=GITHUB_REPO,
-                        help='GitHub repo (default: %s)' % GITHUB_REPO)
+                        help='GitHub repo (default: {0!s})'.format(GITHUB_REPO))
     parser.add_argument('--password',
                         help='PyPI password (will prompt if not provided)')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Trax-air:swagger-stub?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Trax-air:swagger-stub?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
