### PR TITLE
Fix setup to work with pip 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pip.req import parse_requirements
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
+def parse_requirements(filename):
+    """ load requirements from a pip requirements file """
+    lineiter = (line.strip() for line in open(filename))
+    return [line for line in lineiter if line and not line.startswith("#")]
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -14,8 +17,8 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = [str(i.req) for i in parse_requirements('requirements.txt', session=False)]
-test_requirements = [str(i.req) for i in parse_requirements('requirements_dev.txt', session=False)]
+requirements = parse_requirements('requirements.txt')
+test_requirements = parse_requirements('requirements_dev.txt')
 
 setup(
     name='swagger_stub',


### PR DESCRIPTION
pip.req has been moved to pip._internal.req in pip 10 and it is not recommended to use it.